### PR TITLE
Table filter with better behaving "hasNext()"

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,7 @@ Create a `.yml` file under `$SHUNTING_YARD_HOME/conf/` with the correct settings
 
     $SHUNTING_YARD_HOME/bin/replicator.sh --config=$SHUNTING_YARD_HOME/conf/<my-config>.yml
 
+# Legal
+This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
+
+Copyright 2016-2019 Expedia Inc.

--- a/shunting-yard-common/src/main/java/com/hotels/shunting/yard/common/messaging/MessageReader.java
+++ b/shunting-yard-common/src/main/java/com/hotels/shunting/yard/common/messaging/MessageReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2018 Expedia Inc.
+ * Copyright (C) 2016-2019 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,14 @@ package com.hotels.shunting.yard.common.messaging;
 
 import java.io.Closeable;
 import java.util.Iterator;
+import java.util.Optional;
 
 import com.hotels.shunting.yard.common.event.ListenerEvent;
 
 /**
  * A {@code MessageReader} is in charge of retrieving events from the messaging infrastructure.
  */
-public interface MessageReader extends Iterator<ListenerEvent>, Closeable {
+public interface MessageReader extends Closeable {
 
+  Optional<ListenerEvent> next();
 }

--- a/shunting-yard-common/src/main/java/com/hotels/shunting/yard/common/metrics/MetricsConstant.java
+++ b/shunting-yard-common/src/main/java/com/hotels/shunting/yard/common/metrics/MetricsConstant.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2018 Expedia Inc.
+ * Copyright (C) 2016-2019 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,8 @@ package com.hotels.shunting.yard.common.metrics;
 
 public final class MetricsConstant {
 
-  public static final String EMITTER_FAILURES = "shunting_yard_emitter_failures";
-  public static final String EMITTER_SUCCESSES = "shunting_yard_emitter_successes";
-
   public static final String RECEIVER_FAILURES = "shunting_yard_receiver_failures";
+  public static final String RECEIVER_EMPTY = "shunting_yard_receiver_empty";
   public static final String RECEIVER_SUCCESSES = "shunting_yard_receiver_successes";
 
   private MetricsConstant() {}

--- a/shunting-yard-receiver/shunting-yard-receiver-sqs/src/main/java/com/hotels/shunting/yard/receiver/sqs/messaging/SqsMessageReader.java
+++ b/shunting-yard-receiver/shunting-yard-receiver-sqs/src/main/java/com/hotels/shunting/yard/receiver/sqs/messaging/SqsMessageReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2018 Expedia Inc.
+ * Copyright (C) 2016-2019 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import static com.hotels.shunting.yard.receiver.sqs.SqsReceiverUtils.waitTimeSec
 
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.Optional;
 
 import org.apache.hadoop.conf.Configuration;
 
@@ -63,21 +64,11 @@ public class SqsMessageReader implements MessageReader {
   }
 
   @Override
-  public void remove() {
-    throw new UnsupportedOperationException("Cannot remove message from SQS topic");
-  }
-
-  @Override
-  public boolean hasNext() {
-    return true;
-  }
-
-  @Override
-  public ListenerEvent next() {
+  public Optional<ListenerEvent> next() {
     readRecordsIfNeeded();
     Message message = records.next();
     delete(message);
-    return eventPayLoad(message);
+    return Optional.of(eventPayLoad(message));
   }
 
   private void readRecordsIfNeeded() {

--- a/shunting-yard-receiver/shunting-yard-receiver-sqs/src/test/java/com/hotels/shunting/yard/receiver/sqs/messaging/SqsMessageReaderTest.java
+++ b/shunting-yard-receiver/shunting-yard-receiver-sqs/src/test/java/com/hotels/shunting/yard/receiver/sqs/messaging/SqsMessageReaderTest.java
@@ -93,7 +93,7 @@ public class SqsMessageReaderTest {
 
   @Test
   public void nextReadsRecordsFromQueue() throws Exception {
-    assertThat(reader.next()).isSameAs(event);
+    assertThat(reader.next().get()).isSameAs(event);
     verify(consumer).receiveMessage(receiveMessageRequestCaptor.capture());
     assertThat(receiveMessageRequestCaptor.getValue().getQueueUrl()).isEqualTo(QUEUE_NAME);
     assertThat(receiveMessageRequestCaptor.getValue().getWaitTimeSeconds()).isEqualTo(WAIT_TIME);

--- a/shunting-yard-receiver/shunting-yard-receiver-sqs/src/test/java/com/hotels/shunting/yard/receiver/sqs/messaging/SqsMessageReaderTest.java
+++ b/shunting-yard-receiver/shunting-yard-receiver-sqs/src/test/java/com/hotels/shunting/yard/receiver/sqs/messaging/SqsMessageReaderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2018 Expedia Inc.
+ * Copyright (C) 2016-2019 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,16 +89,6 @@ public class SqsMessageReaderTest {
   public void close() throws Exception {
     reader.close();
     verify(consumer).shutdown();
-  }
-
-  @Test(expected = UnsupportedOperationException.class)
-  public void remove() {
-    reader.remove();
-  }
-
-  @Test
-  public void hasNext() {
-    assertThat(reader.hasNext()).isTrue();
   }
 
   @Test

--- a/shunting-yard-replicator/src/main/java/com/hotels/shunting/yard/replicator/exec/MetaStoreEventReplication.java
+++ b/shunting-yard-replicator/src/main/java/com/hotels/shunting/yard/replicator/exec/MetaStoreEventReplication.java
@@ -98,11 +98,6 @@ public class MetaStoreEventReplication {
   }
 
   @Bean
-  public TaskExecutor taskExecutor() {
-    return new SimpleAsyncTaskExecutor();
-  }
-
-  @Bean
   MetricRegistry runningMetricRegistry() {
     return new MetricRegistry();
   }

--- a/shunting-yard-replicator/src/main/java/com/hotels/shunting/yard/replicator/exec/MetaStoreEventReplication.java
+++ b/shunting-yard-replicator/src/main/java/com/hotels/shunting/yard/replicator/exec/MetaStoreEventReplication.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2018 Expedia Inc.
+ * Copyright (C) 2016-2019 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
+import org.springframework.core.task.TaskExecutor;
 import org.springframework.validation.BindException;
 import org.springframework.validation.ObjectError;
 
@@ -48,15 +50,16 @@ public class MetaStoreEventReplication {
 
     int exitCode = -1;
     try {
-      exitCode = SpringApplication.exit(new SpringApplicationBuilder(MetaStoreEventReplication.class)
-          .properties("spring.config.location:${config:null}")
-          .properties("instance.home:${user.home}")
-          .properties("instance.name:${replica-catalog.name}")
-          .properties("instance.workspace:${instance.home}/.shunting-yard")
-          .registerShutdownHook(true)
-          .listeners(new ConfigFileValidationApplicationListener())
-          .build()
-          .run(args));
+      exitCode = SpringApplication
+          .exit(new SpringApplicationBuilder(MetaStoreEventReplication.class)
+              .properties("spring.config.location:${config:null}")
+              .properties("instance.home:${user.home}")
+              .properties("instance.name:${replica-catalog.name}")
+              .properties("instance.workspace:${instance.home}/.shunting-yard")
+              .registerShutdownHook(true)
+              .listeners(new ConfigFileValidationApplicationListener())
+              .build()
+              .run(args));
     } catch (ConfigFileValidationException e) {
       LOG.error(e.getMessage(), e);
       printHelp(e.getErrors());
@@ -92,6 +95,11 @@ public class MetaStoreEventReplication {
     // ManifestAttributes manifestAttributes = new ManifestAttributes(CircusTrain.class);
     // LOG.info("{}", manifestAttributes);
     LOG.info("MetaStoreEventReplication");
+  }
+
+  @Bean
+  public TaskExecutor taskExecutor() {
+    return new SimpleAsyncTaskExecutor();
   }
 
   @Bean

--- a/shunting-yard-replicator/src/main/java/com/hotels/shunting/yard/replicator/exec/app/ReplicationRunner.java
+++ b/shunting-yard-replicator/src/main/java/com/hotels/shunting/yard/replicator/exec/app/ReplicationRunner.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2018 Expedia Inc.
+ * Copyright (C) 2016-2019 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ class ReplicationRunner implements ApplicationRunner, ExitCodeGenerator {
 
   private final ReplicationMetaStoreEventListener listener;
   private final MetaStoreEventReader eventReader;
+  private boolean running = false;
 
   @Autowired
   ReplicationRunner(MetaStoreEventReader eventReader, ReplicationMetaStoreEventListener listener) {
@@ -51,7 +52,8 @@ class ReplicationRunner implements ApplicationRunner, ExitCodeGenerator {
 
   @Override
   public void run(ApplicationArguments args) {
-    while (true) {
+    running = true;
+    while (running) {
       try {
         Optional<MetaStoreEvent> event = eventReader.next();
         if (event.isPresent()) {
@@ -70,6 +72,10 @@ class ReplicationRunner implements ApplicationRunner, ExitCodeGenerator {
   @Override
   public int getExitCode() {
     return 0;
+  }
+  
+  public void stop() {
+    running = false;
   }
 
 }

--- a/shunting-yard-replicator/src/main/java/com/hotels/shunting/yard/replicator/exec/app/ReplicationRunner.java
+++ b/shunting-yard-replicator/src/main/java/com/hotels/shunting/yard/replicator/exec/app/ReplicationRunner.java
@@ -15,6 +15,8 @@
  */
 package com.hotels.shunting.yard.replicator.exec.app;
 
+import java.util.Optional;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -49,19 +51,20 @@ class ReplicationRunner implements ApplicationRunner, ExitCodeGenerator {
 
   @Override
   public void run(ApplicationArguments args) {
-    while (eventReader.hasNext()) {
+    while (true) {
       try {
-        MetaStoreEvent event = eventReader.next();
-        log.info("New event received: {}", event);
-        listener.onEvent(event);
-        SUCCESS_COUNTER.increment();
+        Optional<MetaStoreEvent> event = eventReader.next();
+        if (event.isPresent()) {
+          log.info("New event received: {}", event);
+          listener.onEvent(event.get());
+          SUCCESS_COUNTER.increment();
+        }
       } catch (Exception e) {
         // ERROR, ShuntingYard and Receiver are keywords
         log.error("Error in ShuntingYard Receiver", e);
         FAILURE_COUNTER.increment();
       }
     }
-    log.info("Finishing event loop");
   }
 
   @Override

--- a/shunting-yard-replicator/src/main/java/com/hotels/shunting/yard/replicator/exec/app/ReplicationRunner.java
+++ b/shunting-yard-replicator/src/main/java/com/hotels/shunting/yard/replicator/exec/app/ReplicationRunner.java
@@ -23,7 +23,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.ExitCodeGenerator;
-import org.springframework.core.task.TaskExecutor;
 import org.springframework.stereotype.Component;
 
 import io.micrometer.core.instrument.Counter;
@@ -75,6 +74,7 @@ class ReplicationRunner implements ApplicationRunner, ExitCodeGenerator {
         FAILURE_COUNTER.increment();
       }
     }
+    log.info("Exiting run loop");
   }
 
   @Override

--- a/shunting-yard-replicator/src/main/java/com/hotels/shunting/yard/replicator/exec/app/ReplicationRunner.java
+++ b/shunting-yard-replicator/src/main/java/com/hotels/shunting/yard/replicator/exec/app/ReplicationRunner.java
@@ -35,7 +35,7 @@ import com.hotels.shunting.yard.replicator.exec.messaging.MetaStoreEventReader;
 import com.hotels.shunting.yard.replicator.exec.receiver.ReplicationMetaStoreEventListener;
 
 @Component
-class ReplicationRunner implements ApplicationRunner, ExitCodeGenerator, Runnable {
+class ReplicationRunner implements ApplicationRunner, ExitCodeGenerator {
   private static final Logger log = LoggerFactory.getLogger(ReplicationRunner.class);
 
   private static final Counter SUCCESS_COUNTER = Metrics.counter(MetricsConstant.RECEIVER_SUCCESSES);
@@ -44,36 +44,18 @@ class ReplicationRunner implements ApplicationRunner, ExitCodeGenerator, Runnabl
 
   private final ReplicationMetaStoreEventListener listener;
   private final MetaStoreEventReader eventReader;
-  private final TaskExecutor executor;
   private boolean running = false;
 
   @Autowired
   ReplicationRunner(
       MetaStoreEventReader eventReader,
-      ReplicationMetaStoreEventListener listener,
-      TaskExecutor executor) {
+      ReplicationMetaStoreEventListener listener) {
     this.listener = listener;
     this.eventReader = eventReader;
-    this.executor = executor;
   }
 
   @Override
   public void run(ApplicationArguments args) {
-    executor.execute(this);
-  }
-
-  @Override
-  public int getExitCode() {
-    return 0;
-  }
-
-  public void stop() {
-    log.info("Stopping");
-    running = false;
-  }
-
-  @Override
-  public void run() {
     running = true;
     log.info("Starting");
     while (running) {
@@ -94,4 +76,15 @@ class ReplicationRunner implements ApplicationRunner, ExitCodeGenerator, Runnabl
       }
     }
   }
+
+  @Override
+  public int getExitCode() {
+    return 0;
+  }
+
+  public void stop() {
+    log.info("Stopping");
+    running = false;
+  }
+
 }

--- a/shunting-yard-replicator/src/main/java/com/hotels/shunting/yard/replicator/exec/messaging/AggregatingMetaStoreEventReader.java
+++ b/shunting-yard-replicator/src/main/java/com/hotels/shunting/yard/replicator/exec/messaging/AggregatingMetaStoreEventReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2018 Expedia Inc.
+ * Copyright (C) 2016-2019 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shunting-yard-replicator/src/main/java/com/hotels/shunting/yard/replicator/exec/messaging/AggregatingMetaStoreEventReader.java
+++ b/shunting-yard-replicator/src/main/java/com/hotels/shunting/yard/replicator/exec/messaging/AggregatingMetaStoreEventReader.java
@@ -48,7 +48,8 @@ public class AggregatingMetaStoreEventReader implements MetaStoreEventReader {
       long maxExecTime = windowUnits.toMillis(window);
       long startTime = System.currentTimeMillis();
       while (startTime + maxExecTime > System.currentTimeMillis()) {
-        //TODO: since delegate.next() effectively blocks until some messages arrive, the below means we could exceed the above aggregate window time
+        // TODO: since delegate.next() effectively blocks until some messages arrive, the below means we could exceed
+        // the above aggregate window time
         Optional<MetaStoreEvent> next = delegate.next();
         if (next.isPresent()) {
           events.add(next.get());
@@ -124,7 +125,7 @@ public class AggregatingMetaStoreEventReader implements MetaStoreEventReader {
         throw new ShuntingYardException("Delegate MessageReader has failed to read messages", cause);
       }
     }
-    return Optional.of(buffer.poll());
+    return Optional.ofNullable(buffer.poll());
   }
 
   private void requestMoreMessagesIfNeeded() {

--- a/shunting-yard-replicator/src/main/java/com/hotels/shunting/yard/replicator/exec/messaging/MessageReaderAdapter.java
+++ b/shunting-yard-replicator/src/main/java/com/hotels/shunting/yard/replicator/exec/messaging/MessageReaderAdapter.java
@@ -19,6 +19,7 @@ import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTOREURIS;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Optional;
 
 import com.hotels.shunting.yard.common.event.AddPartitionEvent;
 import com.hotels.shunting.yard.common.event.AlterPartitionEvent;
@@ -45,13 +46,13 @@ public class MessageReaderAdapter implements MetaStoreEventReader {
   }
 
   @Override
-  public boolean hasNext() {
-    return messageReader.hasNext();
-  }
-
-  @Override
-  public MetaStoreEvent next() {
-    return map(messageReader.next());
+  public Optional<MetaStoreEvent> next() {
+    Optional<ListenerEvent> next = messageReader.next();
+    if (next.isPresent()) {
+      return Optional.of(map(next.get()));
+    } else {
+      return Optional.empty();
+    }
   }
 
   private MetaStoreEvent map(ListenerEvent listenerEvent) {

--- a/shunting-yard-replicator/src/main/java/com/hotels/shunting/yard/replicator/exec/messaging/MetaStoreEventReader.java
+++ b/shunting-yard-replicator/src/main/java/com/hotels/shunting/yard/replicator/exec/messaging/MetaStoreEventReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2018 Expedia Inc.
+ * Copyright (C) 2016-2019 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shunting-yard-replicator/src/main/java/com/hotels/shunting/yard/replicator/exec/messaging/MetaStoreEventReader.java
+++ b/shunting-yard-replicator/src/main/java/com/hotels/shunting/yard/replicator/exec/messaging/MetaStoreEventReader.java
@@ -17,19 +17,12 @@ package com.hotels.shunting.yard.replicator.exec.messaging;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.Iterator;
+import java.util.Optional;
 
 import com.hotels.shunting.yard.replicator.exec.event.MetaStoreEvent;
 
-public interface MetaStoreEventReader extends Iterator<MetaStoreEvent>, Closeable {
+public interface MetaStoreEventReader extends Closeable {
 
-  @Override
-  void close() throws IOException;
-
-  @Override
-  boolean hasNext();
-
-  @Override
-  MetaStoreEvent next();
+  Optional<MetaStoreEvent> next();
 
 }

--- a/shunting-yard-replicator/src/test/java/com/hotels/shunting/yard/replicator/exec/app/ReplicationRunnerTest.java
+++ b/shunting-yard-replicator/src/test/java/com/hotels/shunting/yard/replicator/exec/app/ReplicationRunnerTest.java
@@ -20,6 +20,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -43,8 +45,7 @@ public class ReplicationRunnerTest {
 
   @Before
   public void init() {
-    when(eventReader.hasNext()).thenReturn(true, false);
-    when(eventReader.next()).thenReturn(event);
+    when(eventReader.next()).thenReturn(Optional.of(event));
     runner = new ReplicationRunner(eventReader, listener);
   }
 

--- a/shunting-yard-replicator/src/test/java/com/hotels/shunting/yard/replicator/exec/app/ReplicationRunnerTest.java
+++ b/shunting-yard-replicator/src/test/java/com/hotels/shunting/yard/replicator/exec/app/ReplicationRunnerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2018 Expedia Inc.
+ * Copyright (C) 2016-2019 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 import java.util.Optional;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -54,17 +55,22 @@ public class ReplicationRunnerTest {
     assertThat(runner.getExitCode()).isEqualTo(0);
   }
 
+  @Ignore("TODO: kick runner of in its own thread, then wait for counter for a certain amount of time and either timeout or assert results")
   @Test
   public void onEvent() {
+    //TODO: need to kick runner off in its own thread
     runner.run(args);
+    runner.stop();
     verify(listener).onEvent(event);
     verifyNoMoreInteractions(listener);
   }
 
+  @Ignore("TODO: kick runner of in its own thread, then wait for counter for a certain amount of time and either timeout or assert results")
   @Test
   public void onEventProcessingFailure() {
     when(eventReader.next()).thenThrow(RuntimeException.class);
     runner.run(args);
+    runner.stop();
     verifyNoMoreInteractions(listener);
   }
 

--- a/shunting-yard-replicator/src/test/java/com/hotels/shunting/yard/replicator/exec/app/ReplicationRunnerTest.java
+++ b/shunting-yard-replicator/src/test/java/com/hotels/shunting/yard/replicator/exec/app/ReplicationRunnerTest.java
@@ -64,7 +64,7 @@ public class ReplicationRunnerTest {
   
   private void runRunner() throws InterruptedException {
     executor.execute(new Runner());
-    Thread.sleep(1000);
+    Thread.sleep(500);
     runner.stop();
     executor.awaitTermination(1, TimeUnit.SECONDS);
   }

--- a/shunting-yard-replicator/src/test/java/com/hotels/shunting/yard/replicator/exec/messaging/AggregatingMetaStoreEventReaderTest.java
+++ b/shunting-yard-replicator/src/test/java/com/hotels/shunting/yard/replicator/exec/messaging/AggregatingMetaStoreEventReaderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2018 Expedia Inc.
+ * Copyright (C) 2016-2019 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shunting-yard-replicator/src/test/java/com/hotels/shunting/yard/replicator/exec/messaging/AggregatingMetaStoreEventReaderTest.java
+++ b/shunting-yard-replicator/src/test/java/com/hotels/shunting/yard/replicator/exec/messaging/AggregatingMetaStoreEventReaderTest.java
@@ -61,7 +61,6 @@ public class AggregatingMetaStoreEventReaderTest {
 
   @Before
   public void init() {
-    when(delegate.hasNext()).thenReturn(true);
     when(buffer.isEmpty()).thenReturn(true);
     when(buffer.addAll(any())).thenAnswer(new Answer<Boolean>() {
       @Override

--- a/shunting-yard-replicator/src/test/java/com/hotels/shunting/yard/replicator/exec/messaging/AggregatingMetaStoreEventReaderTest.java
+++ b/shunting-yard-replicator/src/test/java/com/hotels/shunting/yard/replicator/exec/messaging/AggregatingMetaStoreEventReaderTest.java
@@ -69,7 +69,8 @@ public class AggregatingMetaStoreEventReaderTest {
         return (List<MetaStoreEvent>) invocation.getArgument(0);
       }
     });
-    aggregatingMessageReader = new AggregatingMetaStoreEventReader(delegate, aggregator, WINDOW, WINDOW_UNITS, buffer);
+    aggregatingMessageReader =
+        new AggregatingMetaStoreEventReader(delegate, aggregator, WINDOW, WINDOW_UNITS, buffer);
   }
 
   @Test
@@ -82,19 +83,17 @@ public class AggregatingMetaStoreEventReaderTest {
         return Optional.of(events.get(0));
       }
     });
-    aggregatingMessageReader.next();
+    Optional<MetaStoreEvent> next = aggregatingMessageReader.next();
+    assertThat(next.get()).isEqualTo(events.get(0));
     verify(delegate).next();
     verify(aggregator).aggregate(events);
   }
 
   @Test
   public void multipleReadsBeforeExceedingTheWindow() {
-    MetaStoreEvent[] events = new MetaStoreEvent[] {
-        mock(MetaStoreEvent.class),
-        mock(MetaStoreEvent.class),
-        mock(MetaStoreEvent.class),
-        mock(MetaStoreEvent.class),
-        mock(MetaStoreEvent.class) };
+    MetaStoreEvent[] events =
+        new MetaStoreEvent[] { mock(MetaStoreEvent.class), mock(MetaStoreEvent.class),
+            mock(MetaStoreEvent.class), mock(MetaStoreEvent.class), mock(MetaStoreEvent.class) };
     final int counter[] = new int[] { 0 };
     when(delegate.next()).thenAnswer(new Answer<Optional<MetaStoreEvent>>() {
       @Override

--- a/shunting-yard-replicator/src/test/java/com/hotels/shunting/yard/replicator/exec/messaging/AggregatingMetaStoreEventReaderTest.java
+++ b/shunting-yard-replicator/src/test/java/com/hotels/shunting/yard/replicator/exec/messaging/AggregatingMetaStoreEventReaderTest.java
@@ -25,6 +25,7 @@ import static org.powermock.api.mockito.PowerMockito.mock;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.TimeUnit;
 
@@ -81,11 +82,11 @@ public class AggregatingMetaStoreEventReaderTest {
   @Test
   public void readExceedsTheWindow() {
     List<MetaStoreEvent> events = Arrays.asList(mock(MetaStoreEvent.class));
-    when(delegate.next()).thenAnswer(new Answer<MetaStoreEvent>() {
+    when(delegate.next()).thenAnswer(new Answer<Optional<MetaStoreEvent>>() {
       @Override
-      public MetaStoreEvent answer(InvocationOnMock invocation) throws Throwable {
+      public Optional<MetaStoreEvent> answer(InvocationOnMock invocation) throws Throwable {
         WINDOW_UNITS.sleep(WINDOW + 1);
-        return events.get(0);
+        return Optional.of(events.get(0));
       }
     });
     aggregatingMessageReader.next();
@@ -104,11 +105,11 @@ public class AggregatingMetaStoreEventReaderTest {
         mock(MetaStoreEvent.class),
         mock(MetaStoreEvent.class) };
     final int counter[] = new int[] { 0 };
-    when(delegate.next()).thenAnswer(new Answer<MetaStoreEvent>() {
+    when(delegate.next()).thenAnswer(new Answer<Optional<MetaStoreEvent>>() {
       @Override
-      public MetaStoreEvent answer(InvocationOnMock invocation) throws Throwable {
+      public Optional<MetaStoreEvent> answer(InvocationOnMock invocation) throws Throwable {
         WINDOW_UNITS.sleep(counter[0] < events.length - 1 ? 1 : WINDOW);
-        return events[counter[0]++];
+        return Optional.of(events[counter[0]++]);
       }
     });
     aggregatingMessageReader.next();

--- a/shunting-yard-replicator/src/test/java/com/hotels/shunting/yard/replicator/exec/messaging/FilteringMessageReaderTest.java
+++ b/shunting-yard-replicator/src/test/java/com/hotels/shunting/yard/replicator/exec/messaging/FilteringMessageReaderTest.java
@@ -16,8 +16,6 @@
 package com.hotels.shunting.yard.replicator.exec.messaging;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
@@ -56,7 +54,10 @@ public class FilteringMessageReaderTest {
     when(listenerEvent3.getDbName()).thenReturn(DB_NAME);
     when(listenerEvent3.getTableName()).thenReturn(TABLE_NAME3);
 
-    when(delegate.next()).thenReturn(Optional.of(listenerEvent1)).thenReturn(Optional.of(listenerEvent2)).thenReturn(Optional.of(listenerEvent3));
+    when(delegate.next())
+        .thenReturn(Optional.of(listenerEvent1))
+        .thenReturn(Optional.of(listenerEvent2))
+        .thenReturn(Optional.of(listenerEvent3));
   }
 
   @Test
@@ -71,6 +72,9 @@ public class FilteringMessageReaderTest {
     assertThat(event.getDbName()).isEqualTo(DB_NAME);
     assertThat(event.getTableName()).isEqualTo(TABLE_NAME1);
 
+    Optional<ListenerEvent> filtered = filteringMessageReader.next();
+    assertThat(filtered).isEqualTo(Optional.empty());
+
     event = filteringMessageReader.next().get();
     assertThat(event.getDbName()).isEqualTo(DB_NAME);
     assertThat(event.getTableName()).isEqualTo(TABLE_NAME3);
@@ -83,6 +87,9 @@ public class FilteringMessageReaderTest {
     when(tableSelector.canProcess(listenerEvent3)).thenReturn(true);
 
     filteringMessageReader = new FilteringMessageReader(delegate, tableSelector);
+
+    Optional<ListenerEvent> filtered = filteringMessageReader.next();
+    assertThat(filtered).isEqualTo(Optional.empty());
 
     ListenerEvent event = filteringMessageReader.next().get();
     assertThat(event.getDbName()).isEqualTo(DB_NAME);

--- a/shunting-yard-replicator/src/test/java/com/hotels/shunting/yard/replicator/exec/messaging/FilteringMessageReaderTest.java
+++ b/shunting-yard-replicator/src/test/java/com/hotels/shunting/yard/replicator/exec/messaging/FilteringMessageReaderTest.java
@@ -96,7 +96,7 @@ public class FilteringMessageReaderTest {
   @Test
   public void emptyDelegateReader() {
     filteringMessageReader = new FilteringMessageReader(delegate, tableSelector);
-    assertThat(filteringMessageReader.next()).isNull();
+    assertThat(filteringMessageReader.next()).isEqualTo(Optional.empty());
   }
 
 }

--- a/shunting-yard-replicator/src/test/java/com/hotels/shunting/yard/replicator/exec/messaging/MessageReaderAdapterTest.java
+++ b/shunting-yard-replicator/src/test/java/com/hotels/shunting/yard/replicator/exec/messaging/MessageReaderAdapterTest.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.IntStream;
 
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
@@ -90,7 +91,7 @@ public class MessageReaderAdapterTest {
 
   @Test
   public void handlesCreateTableEvent() {
-    when(messageReader.next()).thenReturn(createApiaryTableEvent);
+    when(messageReader.next()).thenReturn(Optional.of(createApiaryTableEvent));
     configureMockedEvent(createApiaryTableEvent);
     when(createApiaryTableEvent.getEventType()).thenReturn(EventType.CREATE_TABLE);
 
@@ -100,14 +101,14 @@ public class MessageReaderAdapterTest {
         .parameters(PARAMETERS)
         .build();
 
-    MetaStoreEvent actual = messageReaderAdapter.next();
+    MetaStoreEvent actual = messageReaderAdapter.next().get();
 
     assertMetaStoreEvent(expected, actual);
   }
 
   @Test
   public void apiaryAddPartitionEvent() {
-    when(messageReader.next()).thenReturn(addApiaryPartitionEvent);
+    when(messageReader.next()).thenReturn(Optional.of(addApiaryPartitionEvent));
     configureMockedEvent(addApiaryPartitionEvent);
 
     when(addApiaryPartitionEvent.getPartitionKeys()).thenReturn(PARTITION_KEYS_MAP);
@@ -122,14 +123,14 @@ public class MessageReaderAdapterTest {
         .parameters(PARAMETERS)
         .build();
 
-    MetaStoreEvent actual = messageReaderAdapter.next();
+    MetaStoreEvent actual = messageReaderAdapter.next().get();
 
     assertMetaStoreEvent(expected, actual);
   }
 
   @Test
   public void apiaryAlterPartitionEvent() {
-    when(messageReader.next()).thenReturn(alterApiaryPartitionEvent);
+    when(messageReader.next()).thenReturn(Optional.of(alterApiaryPartitionEvent));
     configureMockedEvent(alterApiaryPartitionEvent);
 
     when(alterApiaryPartitionEvent.getPartitionKeys()).thenReturn(PARTITION_KEYS_MAP);
@@ -144,14 +145,14 @@ public class MessageReaderAdapterTest {
         .parameters(PARAMETERS)
         .build();
 
-    MetaStoreEvent actual = messageReaderAdapter.next();
+    MetaStoreEvent actual = messageReaderAdapter.next().get();
 
     assertMetaStoreEvent(expected, actual);
   }
 
   @Test
   public void apiaryDropPartitionEvent() {
-    when(messageReader.next()).thenReturn(dropApiaryPartitionEvent);
+    when(messageReader.next()).thenReturn(Optional.of(dropApiaryPartitionEvent));
     configureMockedEvent(dropApiaryPartitionEvent);
 
     when(dropApiaryPartitionEvent.getPartitionKeys()).thenReturn(PARTITION_KEYS_MAP);
@@ -167,7 +168,7 @@ public class MessageReaderAdapterTest {
         .environmentContext(EMPTY_MAP)
         .build();
 
-    MetaStoreEvent actual = messageReaderAdapter.next();
+    MetaStoreEvent actual = messageReaderAdapter.next().get();
 
     assertMetaStoreEvent(expected, actual);
   }
@@ -179,7 +180,7 @@ public class MessageReaderAdapterTest {
         .collect(LinkedHashMap::new,
             (m, i) -> m.put(partitionKeys.get(i).getName(), partitionValues.get(0).getValues().get(i)), Map::putAll);
 
-    when(messageReader.next()).thenReturn(insertApiaryTableEvent);
+    when(messageReader.next()).thenReturn(Optional.of(insertApiaryTableEvent));
     configureMockedEvent(insertApiaryTableEvent);
 
     when(insertApiaryTableEvent.getPartitionKeyValues()).thenReturn(partitionKeyValues);
@@ -193,14 +194,14 @@ public class MessageReaderAdapterTest {
         .parameters(PARAMETERS)
         .build();
 
-    MetaStoreEvent actual = messageReaderAdapter.next();
+    MetaStoreEvent actual = messageReaderAdapter.next().get();
 
     assertMetaStoreEvent(expected, actual);
   }
 
   @Test
   public void apiaryDropTableEvent() {
-    when(messageReader.next()).thenReturn(dropApiaryTableEvent);
+    when(messageReader.next()).thenReturn(Optional.of(dropApiaryTableEvent));
     configureMockedEvent(dropApiaryTableEvent);
     when(dropApiaryTableEvent.getEventType()).thenReturn(EventType.DROP_TABLE);
 
@@ -211,15 +212,9 @@ public class MessageReaderAdapterTest {
         .parameters(PARAMETERS)
         .build();
 
-    MetaStoreEvent actual = messageReaderAdapter.next();
+    MetaStoreEvent actual = messageReaderAdapter.next().get();
 
     assertMetaStoreEvent(expected, actual);
-  }
-
-  @Test
-  public void testHasNext() {
-    messageReaderAdapter.hasNext();
-    verify(messageReader).hasNext();
   }
 
   @Test

--- a/shunting-yard-replicator/src/test/resources/log4j.xml
+++ b/shunting-yard-replicator/src/test/resources/log4j.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  Copyright (C) 2016-2019 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j='http://jakarta.apache.org/log4j/'>
+
+  <appender name="CONSOLE" class="org.apache.log4j.ConsoleAppender">
+    <layout class="org.apache.log4j.PatternLayout">
+      <param name="ConversionPattern" value="%d{ISO8601} %-5p %c:%L - %m%n"/>
+    </layout>
+  </appender>
+
+  <logger name="com.hotels.shunting">
+    <level value="DEBUG"/>
+  </logger>
+
+  <root>
+    <level value="INFO"/>
+    <appender-ref ref="CONSOLE"/>
+  </root>
+
+</log4j:configuration>


### PR DESCRIPTION
This turned into a much bigger change than I had anticipated but the basic idea is that since the `FilteringMessageReader` can filter messages out we'd rather return these as empty Optionals than block and wait for something that passes the filter to arrive. While making these changes I also removed the two implementations of `Iterator` since these weren't true iterators any more and were abusing the contract (e.g. always returning true for hasNext(), throwing Exceptions for unimplemented remove() methods etc.). I then noticed that the main loop controlling the `ReplicationRunner` could be improved by firing it off in a separate thread and running while true