### PR TITLE
Excluded `org.pentaho.pentaho-aggdesigner-algorithm` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Fixed
 * `FilteringMessageReader` now deletes filtered messages to mimic previous behaviour of delete on read.
 
+### Changed
+- Excluded `org.pentaho.pentaho-aggdesigner-algorithm` dependency as it's not available in Maven Central.
+
 ## [2.0.0] - 2019-04-16
 ### Added
 * Support for specifying target database and table name.

--- a/shunting-yard-common/pom.xml
+++ b/shunting-yard-common/pom.xml
@@ -41,6 +41,12 @@
     <dependency>
       <groupId>org.apache.hive.hcatalog</groupId>
       <artifactId>hive-webhcat-java-client</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.pentaho</groupId>
+          <artifactId>pentaho-aggdesigner-algorithm</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.hotels</groupId>

--- a/shunting-yard-replicator/pom.xml
+++ b/shunting-yard-replicator/pom.xml
@@ -92,6 +92,12 @@
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-exec</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.pentaho</groupId>
+          <artifactId>pentaho-aggdesigner-algorithm</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.hotels</groupId>


### PR DESCRIPTION
This dependency isn't available in Maven Central and means you can't build the project if you don't have a settings.xml file (i.e. Maven defaults).